### PR TITLE
Fix incomplete-uni-patterns warnings, move DynFlags out of HieDb

### DIFF
--- a/hiedb.cabal
+++ b/hiedb.cabal
@@ -17,18 +17,27 @@ source-repository head
   type: git
   location: https://github.com/wz1000/HieDb
 
+common common-options
+  default-language:    Haskell2010
+  build-depends:       base >= 4.12 && < 4.15
+  ghc-options:         -Wall
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wcompat
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wpartial-fields
+                       -Wno-unrecognised-pragmas
 executable hiedb
+  import:              common-options
   hs-source-dirs:      exe
   main-is:             Main.hs
-  -- other-modules:
-  -- other-extensions:
   build-depends:       base
                      , hiedb
                      , ghc-paths
-  ghc-options:         -Wall
-  default-language:    Haskell2010
 
 library
+  import:              common-options
   hs-source-dirs:      src
   exposed-modules:     HieDb,
                        HieDb.Utils,
@@ -38,8 +47,7 @@ library
                        HieDb.Dump,
                        HieDb.Html,
                        HieDb.Run
-  build-depends:       base >= 4.12 && < 4.15
-                     , ghc >= 8.6
+  build-depends:       ghc >= 8.6
                      , array
                      , containers
                      , filepath
@@ -54,22 +62,18 @@ library
                      , lucid
                      , optparse-applicative
                      , terminal-size
-  hs-source-dirs:      src
-  default-language:    Haskell2010
-  ghc-options:         -Wall
 
 test-suite hiedb-tests
-    type:               exitcode-stdio-1.0
-    hs-source-dirs:     test
-    main-is:            Main.hs
-    other-modules:      Test.Orphans
-    build-tool-depends: hiedb:hiedb
-    build-depends:      base >= 4.12 && < 4.15
-                      , directory
-                      , filepath
-                      , ghc >= 8.6
-                      , ghc-paths
-                      , hiedb
-                      , hspec
-                      , process
-    default-language:   Haskell2010
+  import:             common-options
+  type:               exitcode-stdio-1.0
+  hs-source-dirs:     test
+  main-is:            Main.hs
+  other-modules:      Test.Orphans
+  build-tool-depends: hiedb:hiedb
+  build-depends:      directory
+                    , filepath
+                    , ghc >= 8.6
+                    , ghc-paths
+                    , hiedb
+                    , hspec
+                    , process

--- a/src/HieDb/Query.hs
+++ b/src/HieDb/Query.hs
@@ -158,9 +158,10 @@ declRefs db = do
     "refs.dot"
     ( export
         ( ( defaultStyle ( \( _, hie, occ, _, _, _, _ ) -> hie <> ":" <> occ ) )
-          { vertexAttributes = \( mod', _, v : occ, _, _, _, _ ) ->
-              [ "label" G.:= ( mod' <> "." <> occ )
-              , "fillcolor" G.:= case v of 'v' -> "red"; 't' -> "blue" ; _ -> "black" ]
+          { vertexAttributes = \( mod', _, occ, _, _, _, _ ) ->
+              [ "label" G.:= ( mod' <> "." <> drop 1 occ )
+              , "fillcolor" G.:= case occ of ('v':_) -> "red"; ('t':_) -> "blue";_ -> "black"
+              ]
           }
         )
         graph

--- a/src/HieDb/Types.hs
+++ b/src/HieDb/Types.hs
@@ -13,7 +13,7 @@ import Prelude hiding (mod)
 import Name
 import Module
 import NameCache
-import DynFlags
+
 import IfaceEnv (NameCacheUpdater(..))
 import Data.IORef
 
@@ -34,7 +34,7 @@ import Database.SQLite.Simple.FromField
 
 import qualified Text.ParserCombinators.ReadP as R
 
-data HieDb = HieDb { getConn :: Connection, getDbDynFlags :: Maybe DynFlags }
+newtype HieDb = HieDb { getConn :: Connection }
 
 data HieDbException
   = IncompatibleSchemaVersion
@@ -44,7 +44,7 @@ data HieDbException
 instance Exception HieDbException where
 
 setHieTrace :: HieDb -> Maybe (T.Text -> IO ()) -> IO ()
-setHieTrace (getConn -> conn) = setTrace conn
+setHieTrace = setTrace . getConn
 
 data ModuleInfo
   = ModuleInfo

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,7 +1,7 @@
 module Main where
 
 import GHC.Paths (libdir)
-import HieDb (HieDb, HieModuleRow (..), LibDir (..), ModuleInfo (..), withHieDb')
+import HieDb (HieDb, HieModuleRow (..), LibDir (..), ModuleInfo (..), withHieDb)
 import HieDb.Query (getAllIndexedMods, lookupHieFile, resolveUnitId)
 import HieDb.Run (Command (..), Options (..), runCommand)
 import HieDb.Types (HieDbErr (..))
@@ -239,7 +239,7 @@ testTmp :: FilePath
 testTmp = "test" </> "tmp"
 
 withTestDb :: (HieDb -> IO a) -> IO a
-withTestDb = withHieDb' (LibDir libdir) testDb
+withTestDb = withHieDb testDb
 
 runCommandTest :: Command -> IO ()
 runCommandTest = runCommand (LibDir libdir) testOpts

--- a/test/Test/Orphans.hs
+++ b/test/Test/Orphans.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Test.Orphans where
 
 import HieDb.Types
@@ -11,9 +12,9 @@ instance Show OccName where show = occNameString
 instance Show Name where
   show n =
     let occ = nameOccName n
-        mod = nameModule n
-        mn = moduleName mod
-        uid = moduleUnitId mod
+        mod' = nameModule n
+        mn = moduleName mod'
+        uid = moduleUnitId mod'
     in show uid <> ":" <> show mn <> ":" <> show occ
 
 deriving instance Show HieDbErr


### PR DESCRIPTION
- Enable more commonsense warnings across all cabal components
- Remove `Maybe DynFlags` field from `HieDb`.