### PR TITLE
Include test data in hackage source tarball

### DIFF
--- a/hiedb.cabal
+++ b/hiedb.cabal
@@ -13,6 +13,8 @@ category:            Development
 extra-source-files:
   CHANGELOG.md
   README.md
+  test/data/*.hs
+  test/data/Sub/*.hs
 
 
 source-repository head


### PR DESCRIPTION
Currently building from a hackage tarball will fail tests:

```
Running 1 test suites...
Test suite hiedb-tests: RUNNING...
hiedb-tests: test/data/Module1.hs: openFile: does not exist (No such file or directory)
Test suite hiedb-tests: FAIL
```