### PR TITLE
Add compatibility for GHC 9.2

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -9,8 +9,3 @@ source-repository-package
   tag: d8ee6cf80e27f9619d621c936bb4bda4b99a183f
   -- https://github.com/jwaldmann/blaze-textual/commit/d8ee6cf80e27f9619d621c936bb4bda4b99a183f
   -- https://github.com/bos/blaze-textual/issues/13
-
-source-repository-package
-  type: git
-  location: https://github.com/hsyl20/ghc-api-compat
-  tag: 6178d75772c7d923918dfffa0b1f503dfb36d0a6

--- a/hiedb.cabal
+++ b/hiedb.cabal
@@ -71,8 +71,6 @@ library
                      , extra
                      , ansi-terminal
                      , terminal-size
-  if impl(ghc >= 9.0)
-    build-depends: ghc-api-compat
 
 test-suite hiedb-tests
   import:             common-options
@@ -89,5 +87,3 @@ test-suite hiedb-tests
                     , hspec
                     , process
                     , temporary
-  if impl(ghc >= 9.0)
-    build-depends: ghc-api-compat

--- a/src/HieDb/Compat.hs
+++ b/src/HieDb/Compat.hs
@@ -1,5 +1,5 @@
 
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP, PatternSynonyms, ViewPatterns #-}
 module HieDb.Compat (
     nodeInfo'
     , Unit
@@ -7,12 +7,118 @@ module HieDb.Compat (
     , stringToUnit
     , moduleUnit
     , unhelpfulSpanFS
-
+    -- * Types re-exports
+    , ModuleName
+    , mkModuleName
+    , moduleName
+    , moduleNameString
+    , Fingerprint
+    , unpackFS
+    , readHexFingerprint
+    , getFileHash
+    , NameSpace
+    , OccName
+    , mkOccName
+    , nameOccName
+    , occNameSpace
+    , occNameString
+    , mkVarOccFS
+    , Name
+    , nameSrcSpan
+    , NameCacheUpdater(..)
+    , NameCache
+    , nsNames
+    , initNameCache
+    , lookupOrigNameCache
+    , Module
+    , mkModule
+    , nameModule_maybe
+    , nameModule
+    , varName
+    , isVarNameSpace
+    , dataName
+    , isDataConNameSpace
+    , tcClsName
+    , isTcClsNameSpace
+    , tvName
+    , isTvNameSpace
+    , flLabel
+    -- * Dynflags re-exports
+    , DynFlags
+    , defaultDynFlags
+    , LlvmConfig(..)
+    -- * AvailInfo
+    , Avail.AvailInfo
+    , pattern AvailName
+    , pattern AvailFL
+    , pattern AvailTC
+    , flSelector
+    -- * SrcSpan
+    , SrcSpan(..)
+    , RealSrcSpan
+    , mkRealSrcLoc
+    , mkRealSrcSpan
+    , srcSpanStartLine
+    , srcSpanStartCol
+    , srcSpanEndLine
+    , srcSpanEndCol
+    , mkSplitUniqSupply
+    -- * Systools
+    , initSysTools
+    -- * Hie Types
+    , HiePath
+    , hiePathToFS
+    -- * Outputable
+    , (<+>)
+    , ppr
+    , showSDoc
+    , hang
+    , text
+    -- * FastString
+    , FastString
+    -- * IFace
+    , IfaceType
+    , IfaceTyCon(..)
 ) where
 
 import Compat.HieTypes
 
+#if __GLASGOW_HASKELL__ >= 900
+import GHC.Data.FastString as FS
+import GHC.Driver.Session
+import GHC.Iface.Env
+import GHC.Iface.Type
+import GHC.SysTools
+import qualified GHC.Types.Avail as Avail
+import GHC.Types.FieldLabel
+import GHC.Types.Name
+import GHC.Types.Name.Cache
+import GHC.Types.Unique.Supply
+import GHC.Unit.Types
+import GHC.Unit.Module.Name
+import GHC.Utils.Fingerprint
+#if __GLASGOW_HASKELL__ >= 902
+import GHC.Driver.Ppr (showSDoc)
+import GHC.Utils.Outputable (ppr, (<+>), hang, text)
+#else
+import GHC.Utils.Outputable (showSDoc, ppr, (<+>), hang, text)
+#endif
+#else
+import DynFlags
+import FastString
+import Fingerprint
+import FieldLabel
 import Module
+import Name
+import NameCache
+import Outputable (showSDoc, ppr, (<+>), hang, text)
+import IfaceEnv (NameCacheUpdater(..))
+import IfaceType
+import UniqSupply
+import SrcLoc
+import SysTools
+import qualified Avail
+#endif
 
 #if __GLASGOW_HASKELL__ >= 900
 import GHC.Types.SrcLoc
@@ -53,6 +159,39 @@ unhelpfulSpanFS :: FS.FastString -> FS.FastString
 unhelpfulSpanFS = id
 #endif
 
-#if __GLASGOW_HASKELL__ >= 900
+#if __GLASGOW_HASKELL__ < 902
+type HiePath = FastString
+#endif
+
+hiePathToFS :: HiePath -> FastString
+#if __GLASGOW_HASKELL__ >= 902
+hiePathToFS (LexicalFastString fs) = fs
 #else
+hiePathToFS fs = fs
+#endif
+
+{-# COMPLETE AvailTC, AvailName, AvailFL #-}
+
+pattern AvailTC :: Name -> [Name] -> [FieldLabel] -> Avail.AvailInfo
+#if __GLASGOW_HASKELL__ >= 902
+pattern AvailTC n names pieces <- Avail.AvailTC n ((\gres -> foldr (\gre (names, pieces) -> case gre of
+      Avail.NormalGreName name -> (name: names, pieces)
+      Avail.FieldGreName label -> (names, label:pieces)) ([], []) gres) -> (names, pieces))
+#else
+pattern AvailTC n names pieces <- Avail.AvailTC n names pieces
+#endif
+
+pattern AvailName :: Name -> Avail.AvailInfo
+#if __GLASGOW_HASKELL__ >= 902
+pattern AvailName n <- Avail.Avail (Avail.NormalGreName n)
+#else
+pattern AvailName n <- Avail.Avail n
+#endif
+
+pattern AvailFL :: FieldLabel -> Avail.AvailInfo
+#if __GLASGOW_HASKELL__ >= 902
+pattern AvailFL fl <- Avail.Avail (Avail.FieldGreName fl)
+#else
+-- pattern synonym that is never populated
+pattern AvailFL x <- Avail.Avail ((\_ -> (True, undefined)) -> (False, x))
 #endif

--- a/src/HieDb/Create.hs
+++ b/src/HieDb/Create.hs
@@ -12,9 +12,6 @@ import Compat.HieTypes
 import Compat.HieUtils
 
 import GHC
-import IfaceType
-import Name
-import GHC.Fingerprint
 
 import Control.Exception
 import Control.Monad
@@ -32,10 +29,9 @@ import System.Directory
 
 import Database.SQLite.Simple
 
-import HieDb.Compat
+import HieDb.Compat as Compat
 import HieDb.Types
 import HieDb.Utils
-import FastString  as FS      ( FastString )
 
 sCHEMA_VERSION :: Integer
 sCHEMA_VERSION = 6
@@ -196,7 +192,7 @@ addTypeRefs db path hf ixs = mapM_ addTypesFromAst asts
   where
     arr :: A.Array TypeIndex HieTypeFlat
     arr = hie_types hf
-    asts :: M.Map FS.FastString (HieAST TypeIndex)
+    asts :: M.Map HiePath (HieAST TypeIndex)
     asts = getAsts $ hie_asts hf
     addTypesFromAst :: HieAST TypeIndex -> IO ()
     addTypesFromAst ast = do

--- a/src/HieDb/Dump.hs
+++ b/src/HieDb/Dump.hs
@@ -7,12 +7,11 @@ import qualified Compat.HieTypes as HieTypes
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
-import qualified Outputable
 
 import           Compat.HieTypes (HieFile (..))
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Data.Text (Text)
-import           DynFlags (DynFlags)
+import           HieDb.Compat
 import           HieDb.Types (NameCacheMonad)
 import           HieDb.Utils (withHieFile)
 
@@ -25,7 +24,7 @@ dump ::
 dump dynFlags hieFilePath = do
   withHieFile hieFilePath $ \HieFile{ hie_asts } -> do
     let (_, astRoot) = Map.findMin $ HieTypes.getAsts hie_asts
-    liftIO $ putStrLn $ Outputable.showSDoc dynFlags $ HieDebug.ppHie astRoot
+    liftIO $ putStrLn $ showSDoc dynFlags $ HieDebug.ppHie astRoot
 
 {-| Get lines of original source code from given .hie file -}
 sourceCode :: (NameCacheMonad m, MonadIO m) => FilePath -> m [Text]

--- a/src/HieDb/Html.hs
+++ b/src/HieDb/Html.hs
@@ -14,7 +14,8 @@ import           Data.List (foldl', sortBy)
 import           Data.Text   (Text)
 import qualified Data.Text as T
 import           Lucid
-import           Module
+
+import           HieDb.Compat
 
 generate :: FilePath -> ModuleName -> [Text] -> [Span] -> IO ()
 generate fp mn ts sps = renderToFile fp $ doctypehtml_ $ do

--- a/src/HieDb/Query.hs
+++ b/src/HieDb/Query.hs
@@ -12,8 +12,6 @@ import qualified Algebra.Graph.Export.Dot as G
 
 import           GHC
 import           Compat.HieTypes
--- import           Module
-import           Name
 
 import           System.Directory
 import           System.FilePath
@@ -30,7 +28,7 @@ import qualified Data.Set as Set
 import qualified Data.Text as T
 import           Data.IORef
 
-import Database.SQLite.Simple
+import           Database.SQLite.Simple
 
 import           HieDb.Dump (sourceCode)
 import           HieDb.Compat

--- a/src/HieDb/Run.hs
+++ b/src/HieDb/Run.hs
@@ -12,11 +12,6 @@ import Prelude hiding (mod)
 import GHC
 import Compat.HieTypes
 import Compat.HieUtils
-import Name
-import Outputable ((<+>),hang,showSDoc,ppr,text)
-import IfaceType (IfaceType)
-
-import qualified FastString as FS
 
 import qualified Data.Map as M
 
@@ -412,7 +407,7 @@ runCommand libdir opts cmd = withHieDbAndFlags libdir (database opts) $ \dynFlag
                    ,Just $ Left $ defSrc row
                    )]
               Nothing -> do
-                reportAmbiguousErr opts $ Left $ NameUnhelpfulSpan name (FS.unpackFS $ unhelpfulSpanFS msg)
+                reportAmbiguousErr opts $ Left $ NameUnhelpfulSpan name (unpackFS $ unhelpfulSpanFS msg)
     InfoAtPoint target sp mep -> hieFileCommand conn opts target $ \hf -> do
       mapM_ (uncurry $ printInfo dynFlags) $ pointCommand hf sp mep $ \ast ->
         (hieTypeToIface . flip recoverFullType (hie_types hf) <$> nodeInfo' ast, nodeSpan ast)

--- a/src/HieDb/Types.hs
+++ b/src/HieDb/Types.hs
@@ -11,12 +11,6 @@ module HieDb.Types where
 
 import Prelude hiding (mod)
 
-import Name
-import Module
-import NameCache
-import Fingerprint
-
-import IfaceEnv (NameCacheUpdater(..))
 import Data.IORef
 
 import qualified Data.Text as T

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -7,8 +7,7 @@ import HieDb.Query (getAllIndexedMods, lookupHieFile, resolveUnitId, lookupHieFi
 import HieDb.Run (Command (..), Options (..), runCommand)
 import HieDb.Types (HieDbErr (..), SourceFile(..), runDbM)
 import HieDb.Utils (makeNc)
-import HieDb.Compat (stringToUnit)
-import Module (mkModuleName, moduleNameString)
+import HieDb.Compat (stringToUnit, moduleNameString, mkModuleName, getFileHash)
 import System.Directory (findExecutable, getCurrentDirectory, removeDirectoryRecursive)
 import System.Exit (ExitCode (..), die)
 import System.FilePath ((</>))
@@ -19,7 +18,6 @@ import System.IO
 import Test.Hspec (Expectation, Spec, afterAll_, around, beforeAll_, describe, hspec, it, runIO,
                    shouldBe, shouldEndWith)
 import Test.Orphans ()
-import GHC.Fingerprint
 import Data.IORef
 import Data.List (sort)
 import Data.Maybe (fromMaybe)
@@ -216,7 +214,9 @@ cliSpec =
         runHieDbCli ["point-info", "Module1", "10", "10"]
           `succeedsWithStdin` unlines
             [ "Span: test/data/Module1.hs:10:8-11"
-#if __GLASGOW_HASKELL__ >= 900
+#if __GLASGOW_HASKELL__ >= 902
+            , "Constructors: {(XExpr, HsExpr), (HsVar, HsExpr)}"
+#elif __GLASGOW_HASKELL__ >= 900
             , "Constructors: {(HsVar, HsExpr), (XExpr, HsExpr)}"
 #else
             , "Constructors: {(HsVar, HsExpr), (HsWrap, HsExpr)}"

--- a/test/Test/Orphans.hs
+++ b/test/Test/Orphans.hs
@@ -1,14 +1,13 @@
-{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE StandaloneDeriving, CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Test.Orphans where
 
 import HieDb.Compat
 import HieDb.Types
-import Module (ModuleName, moduleName, moduleNameString)
-import Name (Name, nameModule, nameOccName)
-import OccName (OccName, occNameString)
 
+#if __GLASGOW_HASKELL__ < 902
 instance Show ModuleName where show = moduleNameString
+#endif
 instance Show OccName where show = occNameString
 instance Show Name where
   show n =


### PR DESCRIPTION
Also, ditch dependency on `ghc-api-compat` so that
`hiedb` can actually be published to Hackage.

Depends on https://github.com/haskell/haskell-language-server/pull/2003