### PR TITLE
Remove NO-BREAK SPACE

### DIFF
--- a/hiedb.cabal
+++ b/hiedb.cabal
@@ -17,7 +17,7 @@ extra-source-files:
   test/data/Sub/*.hs
 tested-with:         GHC ==8.8.1 || ==8.8.2  || ==8.8.3  || ==8.8.4
                      || ==8.10.1 || ==8.10.2 || ==8.10.3 || ==8.10.4
-                     || ==9.0.1
+                     || ==9.0.1
 
 
 source-repository head


### PR DESCRIPTION
The "NO-BREAK SPACE" character here was causing an issue in Cabal parsing of "not implemented 239". I'm not really sure why this happens, but it's pretty easy to just use a regular space here.