### PR TITLE
Fix compatibility with algebraic-graphs 0.7

### DIFF
--- a/src/HieDb/Query.hs
+++ b/src/HieDb/Query.hs
@@ -267,4 +267,4 @@ getReachableUnreachable db symbols = do
   return (Set.toList xs, Set.toList ys)
 
 splitByReachability :: Ord a => AdjacencyMap a -> [a] -> (Set a, Set a)
-splitByReachability m vs = let s = Set.fromList (dfs vs m) in (s, vertexSet m Set.\\ s)
+splitByReachability m vs = let s = Set.fromList (dfs m vs) in (s, vertexSet m Set.\\ s)


### PR DESCRIPTION
`algebraic-graphs` reordered arguments in 0.7: https://github.com/snowleopard/alga/commit/6bc4daf40ed93bac6d2255aeb23e1b95c4a16ed8
Related: https://github.com/wz1000/HieDb/issues/42

Builds fine and all tests pass here with `algebraic-graphs-0.7` after this change.