### PR TITLE
Index src file in mods using information from hie file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision history for hiedb
 
+## 0.4.4.0 -- 2023-03-30
+* Add indexing src files in `mods`
+
 ## 0.4.3.0 -- 2023-03-13
 
 * Support GHC 9.6

--- a/hiedb.cabal
+++ b/hiedb.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                hiedb
-version:             0.4.3.0
+version:             0.4.4.0
 synopsis:            Generates a references DB from .hie files
 description:         Tool and library to index and query a collection of `.hie` files
 bug-reports:         https://github.com/wz1000/HieDb/issues

--- a/src/HieDb/Create.hs
+++ b/src/HieDb/Create.hs
@@ -224,17 +224,16 @@ addRefsFromLoaded
   :: MonadIO m
   => HieDb -- ^ HieDb into which we're adding the file
   -> FilePath -- ^ Path to @.hie@ file
-  -> SourceFile -- ^ Path to .hs file from which @.hie@ file was created
-                -- Also tells us if this is a real source file?
-                -- i.e. does it come from user's project (as opposed to from project's dependency)?
+  -> SourceFile -- ^ Ignored but maintained for backward compatibility - pass in a (FakeFile Nothing)
+                -- src File information will be retrieved from HieFile
   -> Fingerprint -- ^ The hash of the @.hie@ file
   -> HieFile -- ^ Data loaded from the @.hie@ file
   -> m ()
 addRefsFromLoaded
-  db@(getConn -> conn) path sourceFile hash hf =
+  db@(getConn -> conn) path src hash hf =
     liftIO $ withTransaction conn $ do
       deleteInternalTables conn path
-      addRefsFromLoaded_unsafe db path sourceFile hash hf
+      addRefsFromLoaded_unsafe db path src hash hf
 
 -- | Like 'addRefsFromLoaded' but without:
 --   1) using a transaction
@@ -245,24 +244,24 @@ addRefsFromLoaded_unsafe
   :: MonadIO m
   => HieDb -- ^ HieDb into which we're adding the file
   -> FilePath -- ^ Path to @.hie@ file
-  -> SourceFile -- ^ Path to .hs file from which @.hie@ file was created
-                -- Also tells us if this is a real source file?
-                -- i.e. does it come from user's project (as opposed to from project's dependency)?
+  -> SourceFile -- ^ Ignored but maintained for backward compatibility - pass in a (FakeFile Nothing)
+                -- src File information will be retrieved from HieFile
   -> Fingerprint -- ^ The hash of the @.hie@ file
   -> HieFile -- ^ Data loaded from the @.hie@ file
   -> m ()
 addRefsFromLoaded_unsafe
- db@(getConn -> conn) path sourceFile hash hf = liftIO $ do
+ db@(getConn -> conn) path _ hash hf = liftIO $ do
 
   let isBoot = "boot" `isSuffixOf` path
       mod    = moduleName smod
       uid    = moduleUnit smod
       smod   = hie_module hf
       refmap = generateReferencesMap $ getAsts $ hie_asts hf
-      (srcFile, isReal) = case sourceFile of
-        RealFile f -> (Just f, True)
-        FakeFile mf -> (mf, False)
-      modrow = HieModuleRow path (ModuleInfo mod uid isBoot srcFile isReal hash)
+      isReal = True
+      
+  srcFile <- Just <$> (makeAbsolute $ hie_hs_file hf)
+      
+  let modrow = HieModuleRow path (ModuleInfo mod uid isBoot srcFile isReal hash)
 
   execute conn "INSERT INTO mods VALUES (?,?,?,?,?,?,?)" modrow
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -71,7 +71,7 @@ apiSpec = describe "api" $
               Just modRow -> do
                 hieModuleHieFile modRow `shouldEndWith` "Module1.hie"
                 let modInfo = hieModInfo modRow
-                modInfoIsReal modInfo `shouldBe` False
+                modInfoIsReal modInfo `shouldBe` True
                 modInfoName modInfo `shouldBe` modName
               Nothing -> fail "Should have looked up indexed file"
           it "Should return Nothing for not indexed Module" $ \conn -> do


### PR DESCRIPTION
Currently `hiedb` does not index src files in the `mods` directory making it difficult to get the `hie` file given a src file without resorting to file manipulation since a fake file is passed right now (`lookupHieFileFromSource` does not work). This PR fetches the src file from the `hiefile` which is passed to the `addRefsFromLoaded` and should always exist.


Before:
![image](https://user-images.githubusercontent.com/13813526/228991486-22a93c04-3365-4012-9f0c-7edea4fae723.png)

After:
![image](https://user-images.githubusercontent.com/13813526/228991336-779a3847-965d-49a9-bce7-107dcaa8eb1a.png)
