### PR TITLE
Add --src-base-dir option for indexing in mods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision history for hiedb
 
+## 0.4.4.0 -- 2023-03-31
+* Add `--src-base-dir` option allowing for src file indexing in `mods`
+
 ## 0.4.3.0 -- 2023-03-13
 
 * Support GHC 9.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for hiedb
 
-## 0.4.4.0 -- 2023-03-31
+## 0.4.4.0 -- TODO
 * Add `--src-base-dir` option allowing for src file indexing in `mods`
 
 ## 0.4.3.0 -- 2023-03-13

--- a/hiedb.cabal
+++ b/hiedb.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                hiedb
-version:             0.4.3.0
+version:             0.4.4.0
 synopsis:            Generates a references DB from .hie files
 description:         Tool and library to index and query a collection of `.hie` files
 bug-reports:         https://github.com/wz1000/HieDb/issues

--- a/src/HieDb/Run.hs
+++ b/src/HieDb/Run.hs
@@ -79,6 +79,7 @@ data Options
   , context :: Maybe Natural
   , reindex :: Bool
   , keepMissing :: Bool
+  , srcBaseDir :: Maybe FilePath
   }
 
 data Command
@@ -125,6 +126,7 @@ optParser defdb colr
   <*> optional (option auto (long "context" <> short 'C' <> help "Number of lines of context for source spans - show no context by default"))
   <*> switch (long "reindex" <> short 'r' <> help "Re-index all files in database before running command, deleting those with missing '.hie' files")
   <*> switch (long "keep-missing" <> help "Keep missing files when re-indexing")
+  <*> optional (strOption (long "src-base-dir" <> help "Provide a base directory to index src files as real files"))
   where
     colourFlag = flag' True (long "colour" <> long "color" <> help "Force coloured output")
             <|> flag' False (long "no-colour" <> long "no-color" <> help "Force uncoloured ouput")
@@ -236,7 +238,7 @@ doIndex conn opts h files = do
 
   istart <- offsetTime
   (length -> done, length -> skipped)<- runDbM nc $ partition id <$>
-    zipWithM (\f n -> progress' h (length files) n (addRefsFrom conn) f) files [0..]
+    zipWithM (\f n -> progress' h (length files) n (addRefsFrom conn (srcBaseDir opts)) f) files [0..]
   indexTime <- istart
 
   start <- offsetTime

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -370,4 +370,5 @@ testOpts = Options
   , context = Nothing
   , reindex = False
   , keepMissing = False
+  , srcBaseDir = Nothing
   }


### PR DESCRIPTION
As dicussed in: https://github.com/wz1000/HieDb/pull/48

Adds a `--src-base-dir` option allowing for a source directory to be specified so that source files can be indexed