### PR TITLE
Fix build for ghc 8.10.7

### DIFF
--- a/src/HieDb/Compat.hs
+++ b/src/HieDb/Compat.hs
@@ -157,6 +157,8 @@ combineNodeInfo' :: Ord a => NodeInfo a -> NodeInfo a -> NodeInfo a
     mergeSorted [] bs = bs
 #else
 import qualified FastString as FS
+import qualified Algebra.Graph.AdjacencyMap           as Graph
+import qualified Algebra.Graph.AdjacencyMap.Algorithm as Graph
 
 nodeInfo' :: HieAST TypeIndex -> NodeInfo TypeIndex
 nodeInfo' = nodeInfo


### PR DESCRIPTION
Commit 1e173a1 (Allow algebraic-graphs 0.7) does not build for ghc 8.10.7, as with that compiler we are missing the algebraic-graphs imports we need for `dfs`. This simply adds those in for compiler versions less than 9.0.0.