### PR TITLE
Include recent GHCs in CI config, fix CI, simplify test

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.17.20231219
+# version: 0.17.20240109
 #
-# REGENDATA ("0.17.20231219",["github","cabal.project"])
+# REGENDATA ("0.17.20240109",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -33,6 +33,11 @@ jobs:
             compilerVersion: 9.8.1
             setup-method: ghcup
             allow-failure: false
+          - compiler: ghc-9.6.4
+            compilerKind: ghc
+            compilerVersion: 9.6.4
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.4.8
             compilerKind: ghc
             compilerVersion: 9.4.8
@@ -48,37 +53,17 @@ jobs:
             compilerVersion: 9.0.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.10.7
-            compilerKind: ghc
-            compilerVersion: 8.10.7
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-8.8.4
-            compilerKind: ghc
-            compilerVersion: 8.8.4
-            setup-method: hvr-ppa
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          else
-            apt-add-repository -y 'ppa:hvr/ghc'
-            apt-get update
-            apt-get install -y "$HCNAME"
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          fi
+          mkdir -p "$HOME/.ghcup/bin"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
+          chmod a+x "$HOME/.ghcup/bin/ghcup"
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -90,22 +75,13 @@ jobs:
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-            HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-            HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          else
-            HC=$HCDIR/bin/$HCKIND
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          fi
-
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.12.1
+# version: 0.17.20231219
 #
-# REGENDATA ("0.12.1",["github","cabal.project"])
+# REGENDATA ("0.17.20231219",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -19,64 +19,104 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
+    timeout-minutes:
+      60
     container:
       image: buildpack-deps:bionic
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.0.1
+          - compiler: ghc-9.8.1
+            compilerKind: ghc
+            compilerVersion: 9.8.1
+            setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.10.4
+          - compiler: ghc-9.4.8
+            compilerKind: ghc
+            compilerVersion: 9.4.8
+            setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.10.3
+          - compiler: ghc-9.2.8
+            compilerKind: ghc
+            compilerVersion: 9.2.8
+            setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.10.2
+          - compiler: ghc-9.0.2
+            compilerKind: ghc
+            compilerVersion: 9.0.2
+            setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.10.1
+          - compiler: ghc-8.10.7
+            compilerKind: ghc
+            compilerVersion: 8.10.7
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
-            allow-failure: false
-          - compiler: ghc-8.8.3
-            allow-failure: false
-          - compiler: ghc-8.8.2
-            allow-failure: false
-          - compiler: ghc-8.8.1
+            compilerKind: ghc
+            compilerVersion: 8.8.4
+            setup-method: hvr-ppa
             allow-failure: false
       fail-fast: false
     steps:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common
-          apt-add-repository -y 'ppa:hvr/ghc'
-          apt-get update
-          apt-get install -y $CC cabal-install-3.4
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          else
+            apt-add-repository -y 'ppa:hvr/ghc'
+            apt-get update
+            apt-get install -y "$HCNAME"
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          fi
         env:
-          CC: ${{ matrix.compiler }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-          echo "LANG=C.UTF-8" >> $GITHUB_ENV
-          echo "CABAL_DIR=$HOME/.cabal" >> $GITHUB_ENV
-          echo "CABAL_CONFIG=$HOME/.cabal/config" >> $GITHUB_ENV
-          HCDIR=$(echo "/opt/$CC" | sed 's/-/\//')
-          HCNAME=ghc
-          HC=$HCDIR/bin/$HCNAME
-          echo "HC=$HC" >> $GITHUB_ENV
-          echo "HCPKG=$HCDIR/bin/$HCNAME-pkg" >> $GITHUB_ENV
-          echo "HADDOCK=$HCDIR/bin/haddock" >> $GITHUB_ENV
-          echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
+          echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
+          echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
+          echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
+          HCDIR=/opt/$HCKIND/$HCVER
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+            HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+            HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          else
+            HC=$HCDIR/bin/$HCKIND
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          fi
+
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
-          echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
-          echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
-          echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
-          echo "HEADHACKAGE=false" >> $GITHUB_ENV
-          echo "ARG_COMPILER=--$HCNAME --with-compiler=$HC" >> $GITHUB_ENV
-          echo "GHCJSARITH=0" >> $GITHUB_ENV
+          echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
+          echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
+          echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
+          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
-          CC: ${{ matrix.compiler }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: env
         run: |
           env
@@ -99,6 +139,10 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          cat >> $CABAL_CONFIG <<EOF
+          program-default-options
+            ghc-options: $GHCJOBS +RTS -M3G -RTS
+          EOF
           cat $CABAL_CONFIG
       - name: versions
         run: |
@@ -111,14 +155,14 @@ jobs:
       - name: install cabal-plan
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
-          echo 'de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz' | sha256sum -c -
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.7.3.0/cabal-plan-0.7.3.0-x86_64-linux.xz > cabal-plan.xz
+          echo 'f62ccb2971567a5f638f2005ad3173dba14693a45154c1508645c52289714cb2  cabal-plan.xz' | sha256sum -c -
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -137,23 +181,14 @@ jobs:
       - name: generate cabal.project
         run: |
           PKGDIR_hiedb="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/hiedb-[0-9.]*')"
-          echo "PKGDIR_hiedb=${PKGDIR_hiedb}" >> $GITHUB_ENV
+          echo "PKGDIR_hiedb=${PKGDIR_hiedb}" >> "$GITHUB_ENV"
+          rm -f cabal.project cabal.project.local
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_hiedb}" >> cabal.project
           echo "package hiedb" >> cabal.project
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
-          source-repository-package
-            type:     git
-            location: https://github.com/jwaldmann/blaze-textual.git
-            tag:      d8ee6cf80e27f9619d621c936bb4bda4b99a183f
-
-          source-repository-package
-            type:     git
-            location: https://github.com/hsyl20/ghc-api-compat
-            tag:      6178d75772c7d923918dfffa0b1f503dfb36d0a6
-
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(hiedb)$/; }' >> cabal.project.local
           cat cabal.project
@@ -162,8 +197,8 @@ jobs:
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
-      - name: cache
-        uses: actions/cache@v2
+      - name: restore cache
+        uses: actions/cache/restore@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -187,8 +222,14 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: save cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store

--- a/hiedb.cabal
+++ b/hiedb.cabal
@@ -10,9 +10,10 @@ author:              Zubin Duggal
 maintainer:          zubin.duggal@gmail.com
 copyright:           Zubin Duggal
 category:            Development
-extra-source-files:
-  CHANGELOG.md
+extra-doc-files:
   README.md
+  CHANGELOG.md
+extra-source-files:
   test/data/*.hs
   test/data/Sub/*.hs
 tested-with:         GHC ==9.0.2

--- a/hiedb.cabal
+++ b/hiedb.cabal
@@ -15,9 +15,7 @@ extra-source-files:
   README.md
   test/data/*.hs
   test/data/Sub/*.hs
-tested-with:         GHC ==8.8.4
-                      || ==8.10.7
-                      || ==9.0.2
+tested-with:         GHC ==9.0.2
                       || ==9.2.8
                       || ==9.4.8
                       || ==9.6.4
@@ -31,12 +29,14 @@ common common-options
   default-language:    Haskell2010
   build-depends:       base >= 4.12 && < 4.20
   ghc-options:         -Wall
-                       -Wincomplete-uni-patterns
-                       -Wincomplete-record-updates
                        -Wcompat
                        -Widentities
-                       -Wredundant-constraints
+                       -Wincomplete-record-updates
+                       -Wincomplete-uni-patterns
                        -Wpartial-fields
+                       -Wredundant-constraints
+                       -Wunused-packages
+                       -Wno-name-shadowing
                        -Wno-unrecognised-pragmas
 executable hiedb
   import:              common-options

--- a/hiedb.cabal
+++ b/hiedb.cabal
@@ -35,9 +35,8 @@ common common-options
                        -Wincomplete-uni-patterns
                        -Wpartial-fields
                        -Wredundant-constraints
-                       -Wunused-packages
                        -Wno-name-shadowing
-                       -Wno-unrecognised-pragmas
+
 executable hiedb
   import:              common-options
   hs-source-dirs:      exe

--- a/hiedb.cabal
+++ b/hiedb.cabal
@@ -15,10 +15,13 @@ extra-source-files:
   README.md
   test/data/*.hs
   test/data/Sub/*.hs
-tested-with:         GHC ==8.8.1 || ==8.8.2  || ==8.8.3  || ==8.8.4
-                     || ==8.10.1 || ==8.10.2 || ==8.10.3 || ==8.10.4
-                     || ==9.0.1
-
+tested-with:         GHC ==8.8.4
+                      || ==8.10.7
+                      || ==9.0.2
+                      || ==9.2.8
+                      || ==9.4.8
+                      || ==9.6.4
+                      || ==9.8.1
 
 source-repository head
   type: git

--- a/src/HieDb/Compat.hs
+++ b/src/HieDb/Compat.hs
@@ -1,5 +1,5 @@
 
-{-# LANGUAGE CPP, PatternSynonyms, ViewPatterns #-}
+{-# LANGUAGE CPP, PatternSynonyms, TupleSections, ViewPatterns #-}
 module HieDb.Compat (
     nodeInfo'
     , Unit
@@ -25,7 +25,11 @@ module HieDb.Compat (
     , mkVarOccFS
     , Name
     , nameSrcSpan
+#if __GLASGOW_HASKELL__ >= 903
+    , NameCacheUpdater
+#else
     , NameCacheUpdater(..)
+#endif
     , NameCache
     , nsNames
     , initNameCache
@@ -239,8 +243,9 @@ fieldNameSpace_maybe :: NameSpace -> Maybe FastString
 -- This is horrible, we can improve it once
 -- https://gitlab.haskell.org/ghc/ghc/-/issues/24244 is addressed
 fieldNameSpace_maybe ns = fieldOcc_maybe (mkOccName ns "")
-#endif
+#else
 fieldNameSpace_maybe _ = Nothing
+#endif
 
 #if __GLASGOW_HASKELL__ < 907
 fieldName :: FastString -> NameSpace

--- a/src/HieDb/Compat.hs
+++ b/src/HieDb/Compat.hs
@@ -1,5 +1,5 @@
 
-{-# LANGUAGE CPP, PatternSynonyms, ViewPatterns, TupleSections #-}
+{-# LANGUAGE CPP, PatternSynonyms, ViewPatterns #-}
 module HieDb.Compat (
     nodeInfo'
     , Unit

--- a/src/HieDb/Compat.hs
+++ b/src/HieDb/Compat.hs
@@ -133,14 +133,15 @@ import SysTools
 import qualified Avail
 #endif
 
+import qualified Algebra.Graph.AdjacencyMap           as Graph
+import qualified Algebra.Graph.AdjacencyMap.Algorithm as Graph
+
 #if __GLASGOW_HASKELL__ >= 900
 import GHC.Types.SrcLoc
 import Compat.HieUtils
 
 import qualified Data.Map as M
 import qualified Data.Set as S
-import qualified Algebra.Graph.AdjacencyMap           as Graph
-import qualified Algebra.Graph.AdjacencyMap.Algorithm as Graph
 
 
 -- nodeInfo' :: Ord a => HieAST a -> NodeInfo a

--- a/src/HieDb/Compat.hs
+++ b/src/HieDb/Compat.hs
@@ -1,5 +1,5 @@
 
-{-# LANGUAGE CPP, PatternSynonyms, TupleSections, ViewPatterns #-}
+{-# LANGUAGE CPP, PatternSynonyms, ViewPatterns, TupleSections #-}
 module HieDb.Compat (
     nodeInfo'
     , Unit

--- a/src/HieDb/Create.hs
+++ b/src/HieDb/Create.hs
@@ -183,7 +183,7 @@ addArr (getConn -> conn) arr = do
             mod = moduleName m
             uid = moduleUnit m
         execute conn "INSERT INTO typenames(name,mod,unit) VALUES (?,?,?)" (occ,mod,uid)
-        Just . fromOnly . head <$> query conn "SELECT id FROM typenames WHERE name = ? AND mod = ? AND unit = ?" (occ,mod,uid)
+        fmap fromOnly . listToMaybe <$> query conn "SELECT id FROM typenames WHERE name = ? AND mod = ? AND unit = ?" (occ,mod,uid)
 
 {-| Add references to types from given @.hie@ file to DB. -}
 addTypeRefs

--- a/src/HieDb/Create.hs
+++ b/src/HieDb/Create.hs
@@ -222,7 +222,7 @@ data SkipOptions =
     deriving Show
 
 defaultSkipOptions :: SkipOptions
-defaultSkipOptions = 
+defaultSkipOptions =
   SkipOptions
     {
     skipRefs = False
@@ -323,7 +323,7 @@ addRefsFromLoaded_unsafe
   execute conn "INSERT INTO mods VALUES (?,?,?,?,?,?,?)" modrow
 
   let (rows,decls) = genRefsAndDecls path smod refmap
-  
+
   unless (skipRefs skipOptions) $
     executeMany conn "INSERT INTO refs  VALUES (?,?,?,?,?,?,?,?)" rows
   unless (skipDecls skipOptions) $
@@ -331,7 +331,7 @@ addRefsFromLoaded_unsafe
 
   let defs = genDefRow path smod refmap
   unless (skipDefs skipOptions) $
-    void $ forM defs $ \def -> do
+    forM_ defs $ \def ->
       execute conn "INSERT INTO defs VALUES (?,?,?,?,?,?)" def
 
   let exports = generateExports path $ hie_exports hf

--- a/src/HieDb/Create.hs
+++ b/src/HieDb/Create.hs
@@ -201,7 +201,7 @@ addTypeRefs db path hf ixs = mapM_ addTypesFromAst asts
     addTypesFromAst :: HieAST TypeIndex -> IO ()
     addTypesFromAst ast = do
       mapM_ (addTypeRef db path arr ixs (nodeSpan ast))
-        $ mapMaybe (\x -> guard (any (not . isOccurrence) (identInfo x)) *> identType x)
+        $ mapMaybe (\x -> guard (not (all isOccurrence (identInfo x))) *> identType x)
         $ M.elems
         $ nodeIdentifiers
         $ nodeInfo' ast
@@ -256,7 +256,7 @@ addRefsFrom c@(getConn -> conn) mSrcBaseDir skipOptions path = do
                 (\srcBaseDir ->  do
                     srcFullPath <- makeAbsolute (srcBaseDir </> hie_hs_file hieFile)
                     fileExists <- doesFileExist srcFullPath
-                    pure $ if fileExists then RealFile srcFullPath else (FakeFile Nothing)
+                    pure $ if fileExists then RealFile srcFullPath else FakeFile Nothing
                 )
                 mSrcBaseDir
         addRefsFromLoadedInternal c path srcfile hash skipOptions hieFile

--- a/src/HieDb/Query.hs
+++ b/src/HieDb/Query.hs
@@ -40,7 +40,7 @@ getAllIndexedMods :: HieDb -> IO [HieModuleRow]
 getAllIndexedMods (getConn -> conn) = query_ conn "SELECT * FROM mods"
 
 {-| List all module exports -}
-getAllIndexedExports :: HieDb -> IO [(ExportRow)]
+getAllIndexedExports :: HieDb -> IO [ExportRow]
 getAllIndexedExports (getConn -> conn) = query_ conn "SELECT * FROM exports"
 
 {-| List all exports of the given module -}

--- a/src/HieDb/Run.hs
+++ b/src/HieDb/Run.hs
@@ -241,7 +241,7 @@ progress hndl total cur act f = do
     Just w -> do
       hPutStr hndl $ replicate w ' '
       hPutStr hndl "\r"
-      pure $ take (w-8) $ msg'
+      pure $ take (w-8) msg'
   liftIO $ hPutStr hndl msg
   x <- act f
   if x
@@ -529,7 +529,7 @@ reportRefSpans opts xs = do
                   beforeLines = takeEnd n beforeLines'
                   afterLines  = take    n afterLines'
 
-                  (beforeChars,during') = BS.splitAt (sc-1) $ BS.concat $ intersperse "\n" $ duringLines
+                  (beforeChars,during') = BS.splitAt (sc-1) $ BS.concat $ intersperse "\n" duringLines
                   (during,afterChars) = BS.splitAt (BS.length during' - (BS.length (last duringLines) - ec) - 1) during'
 
                   before = BS.unlines beforeLines <> beforeChars

--- a/src/HieDb/Types.hs
+++ b/src/HieDb/Types.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE BlockArguments #-}

--- a/src/HieDb/Utils.hs
+++ b/src/HieDb/Utils.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE CPP #-}
 module HieDb.Utils where
@@ -39,7 +38,6 @@ import Data.IORef
 import HieDb.Types
 import HieDb.Compat
 import Database.SQLite.Simple
-import Control.Concurrent
 
 addTypeRef :: HieDb -> FilePath -> A.Array TypeIndex HieTypeFlat -> A.Array TypeIndex (Maybe Int64) -> RealSrcSpan -> TypeIndex -> IO ()
 addTypeRef (getConn -> conn) hf arr ixs sp = go 0

--- a/src/HieDb/Utils.hs
+++ b/src/HieDb/Utils.hs
@@ -39,6 +39,10 @@ import HieDb.Types
 import HieDb.Compat
 import Database.SQLite.Simple
 
+#if __GLASGOW_HASKELL__ >= 903
+import Control.Concurrent.MVar (readMVar)
+#endif
+
 addTypeRef :: HieDb -> FilePath -> A.Array TypeIndex HieTypeFlat -> A.Array TypeIndex (Maybe Int64) -> RealSrcSpan -> TypeIndex -> IO ()
 addTypeRef (getConn -> conn) hf arr ixs sp = go 0
   where

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -200,7 +200,7 @@ cliSpec =
             [ "Span: test/data/Sub/Module2.hs:11:7-23"
             , "Constructors: {(ConDeclH98, ConDecl)}"
             , "Identifiers:"
-            , "Symbol:c::Data1Constructor1:Sub.Module2:main"
+            , "Symbol:c:Data1Constructor1:Sub.Module2:main"
             , "Data1Constructor1 defined at test/data/Sub/Module2.hs:11:7-23"
 #if __GLASGOW_HASKELL__ >= 900
             , "    Details:  Nothing {declaration of constructor bound at: test/data/Sub/Module2.hs:11:7-23}"
@@ -215,7 +215,7 @@ cliSpec =
             [ "Span: test/data/Module1.hs:10:8-10"
             , "Constructors: {(HsVar, HsExpr)}"
             , "Identifiers:"
-            , "Symbol:v::not:GHC.Classes:ghc-prim"
+            , "Symbol:v:not:GHC.Classes:ghc-prim"
             , "not defined at <no location info>"
 #if __GLASGOW_HASKELL__ >= 900
             , "    Details:  Just Bool -> Bool {usage}"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -143,7 +143,7 @@ cliSpec =
               ]
         (exitCode, actualStdin, _actualStdErr) <- runHieDbCli ["ls"]
         exitCode `shouldBe` ExitSuccess
-        (sort $ lines actualStdin) `shouldBe` (sort expectedOutput)
+        sort (lines actualStdin) `shouldBe` sort expectedOutput
 
     describe "name-refs" $
       it "lists all references of given function" $ do
@@ -167,8 +167,7 @@ cliSpec =
       it "Prints types of symbol under cursor" $
         runHieDbCli ["point-types", "Module1", "10", "10" ]
           `succeedsWithStdin` unlines
-            [ "Int -> Bool" {- types of `even` function under cursor -}
-            , "forall a. Integral a => a -> Bool"
+            [ "Bool -> Bool" {- type of `not` function under cursor -}
             ]
       it "Fails for symbols that don't have type associated" $ do
         (exitCode, actualStdout, actualStderr) <- runHieDbCli ["point-types", "Module1", "8", "21"]
@@ -213,44 +212,18 @@ cliSpec =
       it "correctly prints type signatures" $
         runHieDbCli ["point-info", "Module1", "10", "10"]
           `succeedsWithStdin` unlines
-#if __GLASGOW_HASKELL__ >= 904
-            [ "Span: test/data/Module1.hs:10:8-11"
-            , "Constructors: {(HsVar, HsExpr), (XExpr, HsExpr)}"
+            [ "Span: test/data/Module1.hs:10:8-10"
+            , "Constructors: {(HsVar, HsExpr)}"
             , "Identifiers:"
-            , "$dIntegral defined at <no location info>"
-            , "    Details:  Just Integral Int {usage of evidence variable}"
-            , "Symbol:v::even:GHC.Real:base"
-            , "even defined at <no location info>"
-            , "    Details:  Just forall a. Integral a => a -> Bool {usage}"
-#elif __GLASGOW_HASKELL__ >= 902
-            [ "Span: test/data/Module1.hs:10:8-11"
-            , "Constructors: {(XExpr, HsExpr), (HsVar, HsExpr)}"
-            , "Identifiers:"
-            , "Symbol:v::even:GHC.Real:base"
-            , "even defined at <no location info>"
-            , "    Details:  Just forall a. Integral a => a -> Bool {usage}"
-            , "$dIntegral defined at <no location info>"
-            , "    Details:  Just Integral Int {usage of evidence variable}"
-#elif __GLASGOW_HASKELL__ >= 900
-            [ "Span: test/data/Module1.hs:10:8-11"
-            , "Constructors: {(HsVar, HsExpr), (XExpr, HsExpr)}"
-            , "Identifiers:"
-            , "Symbol:v::even:GHC.Real:base"
-            , "even defined at <no location info>"
-            , "    Details:  Just forall a. Integral a => a -> Bool {usage}"
-            , "$dIntegral defined at <no location info>"
-            , "    Details:  Just Integral Int {usage of evidence variable}"
+            , "Symbol:v::not:GHC.Classes:ghc-prim"
+            , "not defined at <no location info>"
+#if __GLASGOW_HASKELL__ >= 900
+            , "    Details:  Just Bool -> Bool {usage}"
 #else
-            [ "Span: test/data/Module1.hs:10:8-11"
-            , "Constructors: {(HsVar, HsExpr), (HsWrap, HsExpr)}"
-            , "Identifiers:"
-            , "Symbol:v::even:GHC.Real:base"
-            , "even defined at <no location info>"
-            , "    IdentifierDetails Just forall a. Integral a => a -> Bool {Use}"
+            , "    IdentifierDetails Just Bool -> Bool {Use}"
 #endif
             , "Types:"
-            , "Int -> Bool"
-            , "forall a. Integral a => a -> Bool"
+            , "Bool -> Bool"
             , ""
             ]
 

--- a/test/data/Module1.hs
+++ b/test/data/Module1.hs
@@ -5,9 +5,9 @@ module Module1
 
 import Sub.Module2 (showInt)
 
-function1 :: Int -> String
-function1 i =
-    if even i then "It's even" else "It's odd"
+function1 :: Bool -> String
+function1 b =
+    if not b then "It's false" else "It's true"
 
 function2 :: Int -> IO ()
 function2 i = putStrLn $ showInt i


### PR DESCRIPTION
Hey @wz1000 
Today I noticed that I'm added as a maintainer of this package on hackage.
This made me feel sudden surge or responsibility so I updated the CI of this package to work with all recent versions of GHC :smile: 

- CI config regenerated using recent version of haskell-ci, including all the recent 9+ ghc releases
- updated tested-with to include the most recent patch version of each major ghc release
- simplify one test not to require so much CPP
- fix most ghc warnings and few hlint warnings.
