### PR TITLE
Add skip indexing phase options to hiedb

### DIFF
--- a/hiedb.cabal
+++ b/hiedb.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                hiedb
-version:             0.5.0.0
+version:             0.5.4.0
 synopsis:            Generates a references DB from .hie files
 description:         Tool and library to index and query a collection of `.hie` files
 bug-reports:         https://github.com/wz1000/HieDb/issues

--- a/src/HieDb/Create.hs
+++ b/src/HieDb/Create.hs
@@ -220,6 +220,19 @@ data SkipOptions =
     , skipTypeRefs :: Bool
     }
 
+defaultSkipOptions :: SkipOptions
+defaultSkipOptions = 
+  SkipOptions
+    {
+    skipRefs = False
+    , skipDecls = False
+    , skipDefs = False
+    , skipExports = False
+    , skipTypes = False
+    -- ^ Note skip types will also skip type refs since it is dependent
+    , skipTypeRefs = False
+    }
+
 {-| Adds all references from given @.hie@ file to 'HieDb'.
 The indexing is skipped if the file was not modified since the last time it was indexed.
 The boolean returned is true if the file was actually indexed

--- a/src/HieDb/Create.hs
+++ b/src/HieDb/Create.hs
@@ -331,7 +331,7 @@ addRefsFromLoaded_unsafe
 
   let defs = genDefRow path smod refmap
   unless (skipDefs skipOptions) $
-    forM defs $ \def -> do
+    void $ forM defs $ \def -> do
       execute conn "INSERT INTO defs VALUES (?,?,?,?,?,?)" def
 
   let exports = generateExports path $ hie_exports hf

--- a/src/HieDb/Create.hs
+++ b/src/HieDb/Create.hs
@@ -207,12 +207,25 @@ addTypeRefs db path hf ixs = mapM_ addTypesFromAst asts
         $ nodeInfo' ast
       mapM_ addTypesFromAst $ nodeChildren ast
 
+-- | Options to skip indexing phases
+data SkipOptions =
+  SkipOptions
+    {
+    skipRefs :: Bool
+    , skipDecls :: Bool
+    , skipDefs :: Bool
+    , skipExports :: Bool
+    , skipTypes :: Bool
+    -- ^ Note skip types will also skip type refs since it is dependent
+    , skipTypeRefs :: Bool
+    }
+
 {-| Adds all references from given @.hie@ file to 'HieDb'.
 The indexing is skipped if the file was not modified since the last time it was indexed.
 The boolean returned is true if the file was actually indexed
 -}
-addRefsFrom :: (MonadIO m, NameCacheMonad m) => HieDb -> Maybe FilePath -> FilePath -> m Bool
-addRefsFrom c@(getConn -> conn) mSrcBaseDir path = do
+addRefsFrom :: (MonadIO m, NameCacheMonad m) => HieDb -> Maybe FilePath -> SkipOptions -> FilePath ->  m Bool
+addRefsFrom c@(getConn -> conn) mSrcBaseDir skipOptions path = do
   hash <- liftIO $ getFileHash path
   mods <- liftIO $ query conn "SELECT * FROM mods WHERE hieFile = ? AND hash = ?" (path, hash)
   case mods of
@@ -232,7 +245,7 @@ addRefsFrom c@(getConn -> conn) mSrcBaseDir path = do
                     pure $ if fileExists then RealFile srcFullPath else (FakeFile Nothing)
                 )
                 mSrcBaseDir
-        addRefsFromLoaded c path srcfile hash hieFile
+        addRefsFromLoaded c path srcfile hash skipOptions hieFile
 
 addRefsFromLoaded
   :: MonadIO m
@@ -242,13 +255,14 @@ addRefsFromLoaded
                 -- Also tells us if this is a real source file?
                 -- i.e. does it come from user's project (as opposed to from project's dependency)?
   -> Fingerprint -- ^ The hash of the @.hie@ file
+  -> SkipOptions -- ^ Skip indexing certain tables
   -> HieFile -- ^ Data loaded from the @.hie@ file
   -> m ()
 addRefsFromLoaded
-  db@(getConn -> conn) path sourceFile hash hf =
+  db@(getConn -> conn) path sourceFile hash skipOptions hf =
     liftIO $ withTransaction conn $ do
       deleteInternalTables conn path
-      addRefsFromLoaded_unsafe db path sourceFile hash hf
+      addRefsFromLoaded_unsafe db path sourceFile hash skipOptions hf
 
 -- | Like 'addRefsFromLoaded' but without:
 --   1) using a transaction
@@ -263,10 +277,11 @@ addRefsFromLoaded_unsafe
                 -- Also tells us if this is a real source file?
                 -- i.e. does it come from user's project (as opposed to from project's dependency)?
   -> Fingerprint -- ^ The hash of the @.hie@ file
+  -> SkipOptions -- ^ Skip indexing certain tables
   -> HieFile -- ^ Data loaded from the @.hie@ file
   -> m ()
 addRefsFromLoaded_unsafe
- db@(getConn -> conn) path sourceFile hash hf = liftIO $ do
+ db@(getConn -> conn) path sourceFile hash skipOptions hf = liftIO $ do
 
   let isBoot = "boot" `isSuffixOf` path
       mod    = moduleName smod
@@ -281,18 +296,25 @@ addRefsFromLoaded_unsafe
   execute conn "INSERT INTO mods VALUES (?,?,?,?,?,?,?)" modrow
 
   let (rows,decls) = genRefsAndDecls path smod refmap
-  executeMany conn "INSERT INTO refs  VALUES (?,?,?,?,?,?,?,?)" rows
-  executeMany conn "INSERT INTO decls VALUES (?,?,?,?,?,?,?)" decls
+  
+  unless (skipRefs skipOptions) $
+    executeMany conn "INSERT INTO refs  VALUES (?,?,?,?,?,?,?,?)" rows
+  unless (skipDecls skipOptions) $
+    executeMany conn "INSERT INTO decls VALUES (?,?,?,?,?,?,?)" decls
 
   let defs = genDefRow path smod refmap
-  forM defs $ \def -> do
-    execute conn "INSERT INTO defs VALUES (?,?,?,?,?,?)" def
+  unless (skipDefs skipOptions) $
+    forM defs $ \def -> do
+      execute conn "INSERT INTO defs VALUES (?,?,?,?,?,?)" def
 
   let exports = generateExports path $ hie_exports hf
-  executeMany conn "INSERT INTO exports VALUES (?,?,?,?,?,?,?,?)" exports
+  unless (skipExports skipOptions) $
+    executeMany conn "INSERT INTO exports VALUES (?,?,?,?,?,?,?,?)" exports
 
-  ixs <- addArr db (hie_types hf)
-  addTypeRefs db path hf ixs
+  unless (skipTypes skipOptions) $ do
+    ixs <- addArr db (hie_types hf)
+    unless (skipTypeRefs skipOptions) $ do
+      addTypeRefs db path hf ixs
 
 {-| Add path to .hs source given path to @.hie@ file which has already been indexed.
 No action is taken if the corresponding @.hie@ file has not been indexed yet.

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -103,7 +103,7 @@ apiSpec = describe "api" $
               hash <- getFileHash hie_f
               nc <- newIORef =<< makeNc
               runDbM nc $ withHieFile hie_f $
-                addRefsFromLoaded conn hie_f (RealFile fp) hash defaultSkipOptions 
+                addRefsFromLoaded conn hie_f (RealFile fp) hash
               pure fp
 
             -- Check that it was indexed

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,7 +2,7 @@
 module Main where
 
 import GHC.Paths (libdir, ghc)
-import HieDb (HieDb, HieModuleRow (..), LibDir (..), ModuleInfo (..), withHieDb, withHieFile, addRefsFromLoaded, deleteMissingRealFiles)
+import HieDb (HieDb, HieModuleRow (..), LibDir (..), ModuleInfo (..), withHieDb, withHieFile, addRefsFromLoaded, deleteMissingRealFiles, defaultSkipOptions)
 import HieDb.Query (getAllIndexedMods, lookupHieFile, resolveUnitId, lookupHieFileFromSource)
 import HieDb.Run (Command (..), Options (..), runCommand)
 import HieDb.Types (HieDbErr (..), SourceFile(..), runDbM)
@@ -103,7 +103,7 @@ apiSpec = describe "api" $
               hash <- getFileHash hie_f
               nc <- newIORef =<< makeNc
               runDbM nc $ withHieFile hie_f $
-                addRefsFromLoaded conn hie_f (RealFile fp) hash
+                addRefsFromLoaded conn hie_f (RealFile fp) hash defaultSkipOptions 
               pure fp
 
             -- Check that it was indexed
@@ -388,4 +388,5 @@ testOpts = Options
   , reindex = False
   , keepMissing = False
   , srcBaseDir = Nothing
+  , skipIndexingOptions = defaultSkipOptions
   }


### PR DESCRIPTION
Being able to skip certain phases of indexing can be very useful in practice - particularly skipping the type refs phase which is a massive bottle-neck.

Skipping indexing type refs on Mercury's codebase takes the indexing from **over 7 minutes** to **under 50 seconds** while maintaining most IDE features. Being able to do this as part of an argument would be incredibly useful. Notably I think that phase could be sped up outside of this but I think this feature would be useful as well.