### PR TITLE
search def occname has expects a colon after classification char

### DIFF
--- a/src/HieDb/Query.hs
+++ b/src/HieDb/Query.hs
@@ -152,7 +152,7 @@ searchDef conn cs
   = query (getConn conn) "SELECT defs.*,mods.mod,mods.unit,mods.is_boot,mods.hs_src,mods.is_real,mods.hash \
                          \FROM defs JOIN mods USING (hieFile) \
                          \WHERE occ LIKE ? \
-                         \LIMIT 200" (Only $ '_':cs++"%")
+                         \LIMIT 200" (Only $ '_':':':cs++"%")
 
 {-| @withTarget db t f@ runs function @f@ with HieFile specified by HieTarget @t@.
 In case the target is given by ModuleName (and optionally Unit) it is first resolved


### PR DESCRIPTION
Occ names seem to have a colon separating them from their category (at least on GHC version 9.6.2) causing `searchDef` to fail. Possibly should be conditional on the ghc version (happy to edit this PR if that's the case) but unsure whether/when this changed.

```
sqlite> select occ from defs;
v:bindir
v:catchIO
v:datadir
v:dynlibdir
v:getBinDir
v:getDataDir
v:getDataFileName
v:getDynLibDir
```