### PR TITLE
Avoid inserting duplicate records in typerefs (fixes #61)

### DIFF
--- a/src/HieDb/Create.hs
+++ b/src/HieDb/Create.hs
@@ -37,7 +37,7 @@ import HieDb.Types
 import HieDb.Utils
 
 sCHEMA_VERSION :: Integer
-sCHEMA_VERSION = 7
+sCHEMA_VERSION = 8
 
 dB_VERSION :: Integer
 dB_VERSION = read (show sCHEMA_VERSION ++ "999" ++ show hieVersion)

--- a/src/HieDb/Create.hs
+++ b/src/HieDb/Create.hs
@@ -20,7 +20,7 @@ import Control.Monad.State.Strict (evalStateT)
 
 import qualified Data.Array as A
 import qualified Data.Map as M
-import qualified Data.Set as Set
+import qualified Data.IntMap.Strict as IMap
 
 import Data.Int
 import Data.List ( isSuffixOf )
@@ -203,7 +203,7 @@ addTypeRefs db path hf ixs = mapM_ addTypesFromAst asts
     asts = getAsts $ hie_asts hf
     addTypesFromAst :: HieAST TypeIndex -> IO ()
     addTypesFromAst ast = do
-      flip evalStateT Set.empty
+      flip evalStateT IMap.empty
         $ mapM_ (addTypeRef db path arr ixs (nodeSpan ast))
         $ mapMaybe (\x -> guard (not (all isOccurrence (identInfo x))) *> identType x)
         $ M.elems

--- a/src/HieDb/Utils.hs
+++ b/src/HieDb/Utils.hs
@@ -38,25 +38,39 @@ import Data.IORef
 import HieDb.Types
 import HieDb.Compat
 import Database.SQLite.Simple
+import Control.Monad.State.Strict (StateT, get, put)
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Control.Monad (when)
 
 #if __GLASGOW_HASKELL__ >= 903
 import Control.Concurrent.MVar (readMVar)
 #endif
 
-addTypeRef :: HieDb -> FilePath -> A.Array TypeIndex HieTypeFlat -> A.Array TypeIndex (Maybe Int64) -> RealSrcSpan -> TypeIndex -> IO ()
+-- Each AST Node can have a lot of repetitive type information.
+-- We use this to make sure that each occurrence of a type
+-- (Identified by Int64 id of that type within typenames table)
+-- is inserted exactly once per each RealSrcSpan in which it occurs and per
+-- depth of that type within the tree structure representing the type (Int)
+type TypeIndexing a = StateT (Set (RealSrcSpan, Int64, Int)) IO a
+
+addTypeRef :: HieDb -> FilePath -> A.Array TypeIndex HieTypeFlat -> A.Array TypeIndex (Maybe Int64) -> RealSrcSpan -> TypeIndex -> TypeIndexing ()
 addTypeRef (getConn -> conn) hf arr ixs sp = go 0
   where
     sl = srcSpanStartLine sp
     sc = srcSpanStartCol sp
     el = srcSpanEndLine sp
     ec = srcSpanEndCol sp
-    go :: TypeIndex -> Int -> IO ()
+    go :: Int -> TypeIndex -> TypeIndexing ()
     go d i = do
       case ixs A.! i of
         Nothing -> pure ()
         Just occ -> do
           let ref = TypeRef occ hf d sl sc el ec
-          execute conn "INSERT INTO typerefs VALUES (?,?,?,?,?,?,?)" ref
+          indexed <- get
+          when (Set.notMember (sp, occ, d) indexed) $ do
+            liftIO $ execute conn "INSERT INTO typerefs VALUES (?,?,?,?,?,?,?)" ref
+            put $ Set.insert (sp, occ, d) indexed
       let next = go (d+1)
       case arr A.! i of
         HTyVarTy _ -> pure ()

--- a/src/HieDb/Utils.hs
+++ b/src/HieDb/Utils.hs
@@ -43,7 +43,7 @@ import qualified Data.IntSet as ISet
 import qualified Data.IntMap.Strict as IMap
 import Data.IntMap.Strict (IntMap)
 import Data.IntSet (IntSet)
-import Control.Monad (when)
+import Control.Monad (unless)
 
 #if __GLASGOW_HASKELL__ >= 903
 import Control.Concurrent.MVar (readMVar)
@@ -75,7 +75,7 @@ addTypeRef (getConn -> conn) hf arr ixs sp = go 0
           let ref = TypeRef occ hf depth sl sc el ec
           indexed <- get
           let isTypeIndexed = ISet.member (fromIntegral occ) (IMap.findWithDefault ISet.empty depth indexed)
-          when isTypeIndexed $ do
+          unless isTypeIndexed $ do
             liftIO $ execute conn "INSERT INTO typerefs VALUES (?,?,?,?,?,?,?)" ref
             put $ IMap.alter (\case
                   Nothing -> Just $ ISet.singleton (fromIntegral occ)


### PR DESCRIPTION
First naive attempt at solving https://github.com/wz1000/HieDb/issues/61.

Here's a quick comparison of this PR with master:

1. I built current master of haskell-language-server (to get bunch of .hie files to index):
`cabal clean && cabal build all --ghc-options=-fwrite-ide-info`

2. I indexed that directory with hiedb binary:
```bash
# build hiedb with optimizations:
cabal build --ghc-options=-O2
# find hiedb exe in cabal build dir and use it to index build artifacts in hls repo:
dist-newstyle/build/x86_64-linux/ghc-9.4.8/hiedb-0.5.0.1/x/hiedb/build/hiedb/hiedb -- -D tmp.db index ~/Devel/github.com/haskell/haskell-language-server/
```

- master: 
    - indexing stats: 303 indexed, 0 skipped in 1m13s + 0.07s gc
    - maximum residency: 68 908 kb
    - resulting sqlite size: 218MB
```bash
$ sqlite3 tmp.db "select count(*) from typerefs; select count(*) from (select distinct * from typerefs)"
342879 <<< ~3x redundancy
118819
```

- this PR: 
    - indexing stats: 303 indexed, 0 skipped in 56.61s + 0.07s gc <<< 1.3x faster
    - maximum residency: 69 924 kb
    - resulting sqlite size: 117MB <<< ~50% size reduction
    - no duplicates in sqlite:
```bash
$ sqlite3 tmp.db "select count(*) from typerefs; select count(*) from (select distinct * from typerefs)"
118819 <<< no redundancy
118819
```

You can see that difference with hls codebase is not that significant.
But the difference is much more significant with our work codebase which has much more deriving of stuff:

- master:
    - indexing stats: 208 indexed, 0 skipped in 1m39s + 0.04s gc
    - maximum residency: 68 900 kb
    - sqlite size: 771 MB
```bash
$ sqlite3 tmp.db "select count(*) from typerefs; select count(*) from (select distinct * from typerefs)"
2398458  <<< ~13x redundancy
189136
```
- this PR:
    - indexing stats: 208 indexed, 0 skipped in 41.16s + 0.05s gc  <<< 2.4x faster!
    - maximum residency: 55 232 kb  <<< wut? Even residency is smaller? Probably fluke
    - sqlite size: 102 MB   <<< size reduced by 87%
```bash
$ sqlite3 tmp.db "select count(*) from typerefs; select count(*) from (select distinct * from typerefs)"
189136 <<< no redundancy
189136
```

