### PR TITLE
Track module imports in hiedb

### DIFF
--- a/hiedb.cabal
+++ b/hiedb.cabal
@@ -89,4 +89,6 @@ test-suite hiedb-tests
                     , hiedb
                     , hspec
                     , process
+                    , sqlite-simple
                     , temporary
+                    , text

--- a/hiedb.cabal
+++ b/hiedb.cabal
@@ -89,6 +89,4 @@ test-suite hiedb-tests
                     , hiedb
                     , hspec
                     , process
-                    , sqlite-simple
                     , temporary
-                    , text

--- a/src/HieDb/Run.hs
+++ b/src/HieDb/Run.hs
@@ -139,6 +139,7 @@ optParser defdb colr
         decls <- switch (long "skip-decls" <> help "Skip decls table when indexing")
         defs <- switch (long "skip-defs" <> help "Skip defs table when indexing")
         exports <- switch (long "skip-exports" <> help "Skip exports table when indexing")
+        imports <- switch (long "skip-imports" <> help "Skip imports table when indexing")
         types <- switch (long "skip-types" <> help "Skip types and typerefs table when indexing")
         typeRefs <- switch (long "skip-typerefs" <> help "Skip typerefs table when indexing")
         pure $ SkipOptions
@@ -147,6 +148,7 @@ optParser defdb colr
           , skipDecls = decls
           , skipDefs = defs
           , skipExports = exports
+          , skipImports = imports
           , skipTypes = types
           , skipTypeRefs = typeRefs
           }

--- a/src/HieDb/Types.hs
+++ b/src/HieDb/Types.hs
@@ -188,9 +188,6 @@ data ImportRow
     , importECol :: Int 
     }
 
-instance Show ImportRow where 
-  show = show . toRow
-
 instance FromRow ImportRow where 
   fromRow = 
     ImportRow 

--- a/src/HieDb/Types.hs
+++ b/src/HieDb/Types.hs
@@ -178,6 +178,28 @@ instance FromRow DeclRow where
   fromRow = DeclRow <$> field <*> field <*> field <*> field
                     <*> field <*> field <*> field
 
+data ImportRow 
+  = ImportRow 
+    { importSrc :: FilePath
+    , importModuleName :: ModuleName
+    , importSLine :: Int 
+    , importSCol :: Int 
+    , importELine :: Int 
+    , importECol :: Int 
+    }
+
+instance Show ImportRow where 
+  show = show . toRow
+
+instance FromRow ImportRow where 
+  fromRow = 
+    ImportRow 
+      <$> field <*> field <*> field <*> field 
+      <*> field <*> field
+
+instance ToRow ImportRow where 
+  toRow (ImportRow a b c d e f) = toRow ((a,b,c,d):.(e,f))
+
 data TypeName = TypeName
   { typeName :: OccName
   , typeMod :: ModuleName

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE CPP #-}
 module Main where
 
+import qualified Data.Text as T
+import Database.SQLite.Simple
 import GHC.Paths (libdir, ghc)
-import HieDb (HieDb, HieModuleRow (..), LibDir (..), ModuleInfo (..), withHieDb, withHieFile, addRefsFromLoaded, deleteMissingRealFiles, defaultSkipOptions)
+import HieDb (HieDb, HieModuleRow (..), ImportRow(..), LibDir (..), ModuleInfo (..), withHieDb, withHieFile, addRefsFromLoaded, deleteMissingRealFiles, getConn, defaultSkipOptions)
 import HieDb.Query (getAllIndexedMods, lookupHieFile, resolveUnitId, lookupHieFileFromSource)
 import HieDb.Run (Command (..), Options (..), runCommand)
 import HieDb.Types (HieDbErr (..), SourceFile(..), runDbM)
@@ -15,7 +17,7 @@ import System.Process (callProcess, proc, readCreateProcessWithExitCode)
 import System.Environment (lookupEnv)
 import System.IO.Temp
 import System.IO
-import Test.Hspec (Expectation, Spec, afterAll_, around, beforeAll_, describe, hspec, it, runIO,
+import Test.Hspec (Expectation, Spec, afterAll_, around, beforeAll_, describe, hspec, fit, it, runIO,
                    shouldBe, shouldEndWith)
 import Test.Orphans ()
 import Data.IORef
@@ -81,13 +83,14 @@ apiSpec = describe "api" $
               Just _  -> fail "Lookup suceeded unexpectedly"
 
         describe "deleteMissingRealFiles" $ do
-          it "Should delete missing indexed files and nothing else" $ \conn -> do
+          fit "Should delete missing indexed files and nothing else" $ \conn -> do
 
             originalMods <- getAllIndexedMods conn
 
             -- Index a new real file, and delete it
             let contents = unlines
                   [ "module Test123 where"
+                  , "import Prelude"
                   , "foobarbaz :: Int"
                   , "foobarbaz = 1"
                   ]
@@ -124,6 +127,13 @@ apiSpec = describe "api" $
             afterMods <- getAllIndexedMods conn
             originalMods `shouldBe` afterMods
 
+            imports <- query_ (getConn conn) $ Query $ T.pack "SELECT * FROM imports"
+
+            printImports imports
+            putStrLn $ show (length imports) <> " imports found"
+
+printImports :: [ImportRow] -> IO ()
+printImports = mapM_ print
 
 cliSpec :: Spec
 cliSpec =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,10 +1,8 @@
 {-# LANGUAGE CPP #-}
 module Main where
 
-import qualified Data.Text as T
-import Database.SQLite.Simple
 import GHC.Paths (libdir, ghc)
-import HieDb (HieDb, HieModuleRow (..), ImportRow(..), LibDir (..), ModuleInfo (..), withHieDb, withHieFile, addRefsFromLoaded, deleteMissingRealFiles, getConn, defaultSkipOptions)
+import HieDb (HieDb, HieModuleRow (..), LibDir (..), ModuleInfo (..), withHieDb, withHieFile, addRefsFromLoaded, deleteMissingRealFiles, defaultSkipOptions)
 import HieDb.Query (getAllIndexedMods, lookupHieFile, resolveUnitId, lookupHieFileFromSource)
 import HieDb.Run (Command (..), Options (..), runCommand)
 import HieDb.Types (HieDbErr (..), SourceFile(..), runDbM)
@@ -17,7 +15,7 @@ import System.Process (callProcess, proc, readCreateProcessWithExitCode)
 import System.Environment (lookupEnv)
 import System.IO.Temp
 import System.IO
-import Test.Hspec (Expectation, Spec, afterAll_, around, beforeAll_, describe, hspec, fit, it, runIO,
+import Test.Hspec (Expectation, Spec, afterAll_, around, beforeAll_, describe, hspec, it, runIO,
                    shouldBe, shouldEndWith)
 import Test.Orphans ()
 import Data.IORef
@@ -83,7 +81,7 @@ apiSpec = describe "api" $
               Just _  -> fail "Lookup suceeded unexpectedly"
 
         describe "deleteMissingRealFiles" $ do
-          fit "Should delete missing indexed files and nothing else" $ \conn -> do
+          it "Should delete missing indexed files and nothing else" $ \conn -> do
 
             originalMods <- getAllIndexedMods conn
 
@@ -126,14 +124,6 @@ apiSpec = describe "api" $
             -- Check that the other modules are still indexed
             afterMods <- getAllIndexedMods conn
             originalMods `shouldBe` afterMods
-
-            imports <- query_ (getConn conn) $ Query $ T.pack "SELECT * FROM imports"
-
-            printImports imports
-            putStrLn $ show (length imports) <> " imports found"
-
-printImports :: [ImportRow] -> IO ()
-printImports = mapM_ print
 
 cliSpec :: Spec
 cliSpec =


### PR DESCRIPTION
Would love to get your thoughts on this/upstream this if you think it's useful @wz1000 

Some features/utility that this would enable:
- Easier module graph analysis via sql
- Auto complete for symbols within scope (Could query for what the module's imports and left join exports on the module)
- Filtering out already imported modules from suggested imports

In theory this could be done by traversing the module's imports on the fly but it's nice to have access to that information via the tables.

This also does not demonstrably increase the indexing time either on a codebase the size of mwb from my testing